### PR TITLE
Feature/multer s3

### DIFF
--- a/api/middlewares/uploadAudio.js
+++ b/api/middlewares/uploadAudio.js
@@ -1,0 +1,42 @@
+const multer = require("multer");
+const multerS3 = require("multer-s3");
+const AWS = require("aws-sdk");
+
+const s3 = new AWS.S3({
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  region: process.env.AWS_REGION,
+});
+
+const storage = multerS3({
+  s3,
+  contentType: multerS3.AUTO_CONTENT_TYPE,
+  acl: "public-read",
+  bucket: process.env.AWS_BUCKET_NAME,
+});
+
+// const awsDeleteVideo = async (req, res, next) => {
+//   const {
+//     params: { id }
+//   } = req
+//   const video = await Video.findById(id)  // 현재 URL에 전달된 id값을 받아서 db찾음
+//   const url = video.fileUrl.split('/')    // video에 저장된 fileUrl을 가져옴
+//   const delFileName = url[url.length - 1]  // 버킷에 저장된 객체 URL만 가져옴
+//   const params = {
+//     Bucket: '버킷이름/video',
+//     Key: delFileName
+//   }
+//   s3.deleteObject(params, function(err, data) {
+//     if (err) {
+//       console.log('aws video delete error')
+//       console.log(err, err.stack)
+//     } else {
+//       console.log('aws video delete success' + data)
+//     }
+//   })
+//   next()
+// }
+
+const uploadFile = multer({ storage }).single("file");
+
+module.exports = { uploadFile };

--- a/api/middlewares/uploadAudio.js
+++ b/api/middlewares/uploadAudio.js
@@ -15,28 +15,26 @@ const storage = multerS3({
   bucket: process.env.AWS_BUCKET_NAME,
 });
 
-// const awsDeleteVideo = async (req, res, next) => {
-//   const {
-//     params: { id }
-//   } = req
-//   const video = await Video.findById(id)  // 현재 URL에 전달된 id값을 받아서 db찾음
-//   const url = video.fileUrl.split('/')    // video에 저장된 fileUrl을 가져옴
-//   const delFileName = url[url.length - 1]  // 버킷에 저장된 객체 URL만 가져옴
-//   const params = {
-//     Bucket: '버킷이름/video',
-//     Key: delFileName
-//   }
-//   s3.deleteObject(params, function(err, data) {
-//     if (err) {
-//       console.log('aws video delete error')
-//       console.log(err, err.stack)
-//     } else {
-//       console.log('aws video delete success' + data)
-//     }
-//   })
-//   next()
-// }
+const deleteAudio = async (req, res, next) => {
+  const { filename } = req.body;
 
-const uploadFile = multer({ storage }).single("file");
+  const params = {
+    Bucket: process.env.AWS_BUCKET_NAME,
+    Key: filename,
+  };
 
-module.exports = { uploadFile };
+  s3.deleteObject(params, function (err, data) {
+    if (err) {
+      console.log("aws video delete error");
+      console.log(err, err.stack);
+    } else {
+      console.log("aws video delete success" + data);
+    }
+  });
+
+  next();
+};
+
+const uploadAudio = multer({ storage }).single("file");
+
+module.exports = { uploadAudio, deleteAudio };

--- a/api/middlewares/verifyAccessToken.js
+++ b/api/middlewares/verifyAccessToken.js
@@ -1,0 +1,18 @@
+const jwt = require("jsonwebtoken");
+const createError = require("http-errors");
+
+const verifyAccessToken = (req, res, next) => {
+  const authHeader = req.headers["authorization"];
+  if (!authHeader) return next(createError(401, "Unauthorized"));
+
+  const token = authHeader.split(" ")[1];
+  jwt.verify(token, process.env.ACCESS_TOKEN_SECRET, async (error) => {
+    if (error) {
+      return next(createError(403, "Forbidden"));
+    }
+
+    next();
+  });
+};
+
+module.exports = verifyAccessToken;

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -1,8 +1,10 @@
 const express = require("express");
-const { login } = require("../../services/authService");
+const { login, refreshToken } = require("../../services/authService");
 
 const router = express.Router();
 
 router.post("/login", login);
+
+router.get("/refresh", refreshToken);
 
 module.exports = router;

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -1,17 +1,17 @@
 const express = require("express");
-const { createFile } = require("../../services/userService");
-const { uploadFile } = require("../middlewares/uploadAudio");
+const {
+  createFile,
+  updateFile,
+  deleteFile,
+} = require("../../services/userService");
+const { uploadAudio, deleteAudio } = require("../middlewares/uploadAudio");
 
 const router = express.Router();
 
-router.post("/:id/files/", uploadFile, createFile);
+router.post("/:id/files/", uploadAudio, createFile);
 
-router.put("/:id/files/:fileId", (req, res, next) => {
-  console.log(req.body);
-});
+router.put("/:id/files/:fileId", updateFile);
 
-router.delete("/:id/files/:fileId", (req, res, next) => {
-  console.log(req.body);
-});
+router.delete("/:id/files/:fileId", deleteAudio, deleteFile);
 
 module.exports = router;

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -1,7 +1,17 @@
 const express = require("express");
+const { createFile } = require("../../services/userService");
+const { uploadFile } = require("../middlewares/uploadAudio");
 
 const router = express.Router();
 
-router.post("/:id/files/:fileId", (req, res, next) => {});
+router.post("/:id/files/", uploadFile, createFile);
+
+router.put("/:id/files/:fileId", (req, res, next) => {
+  console.log(req.body);
+});
+
+router.delete("/:id/files/:fileId", (req, res, next) => {
+  console.log(req.body);
+});
 
 module.exports = router;

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const {
+  readFiles,
   createFile,
   updateFile,
   deleteFile,
@@ -7,6 +8,8 @@ const {
 const { uploadAudio, deleteAudio } = require("../middlewares/uploadAudio");
 
 const router = express.Router();
+
+router.get("/:id/files/", readFiles);
 
 router.post("/:id/files/", uploadAudio, createFile);
 

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -7,6 +7,7 @@ const cors = require("cors");
 
 const authRouter = require("../api/routes/auth");
 const usersRouter = require("../api/routes/users");
+const verifyAccessToken = require("../api/middlewares/verifyAccessToken");
 
 const initExpress = ({ app }) => {
   app.use(logger("dev"));
@@ -23,7 +24,7 @@ const initExpress = ({ app }) => {
   );
 
   app.use("/auth", authRouter);
-  app.use("/users", usersRouter);
+  app.use("/users", verifyAccessToken, usersRouter);
 
   app.use((req, res, next) => {
     res.send(createError(404));

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -26,7 +26,7 @@ const initExpress = ({ app }) => {
   app.use("/users", usersRouter);
 
   app.use((req, res, next) => {
-    res.sendStatus(createError(404));
+    res.send(createError(404));
   });
 
   app.use((err, req, res, next) => {

--- a/models/User.js
+++ b/models/User.js
@@ -1,24 +1,21 @@
 const mongoose = require("mongoose");
 
 const subThemeSchema = new mongoose.Schema({
-  time: Number,
-  title: String,
+  min: Number,
+  sec: Number,
+  text: String,
   isAchieved: Boolean,
 });
 
 const fileSchema = new mongoose.Schema({
   title: String,
-  length: Number,
+  min: Number,
+  sec: Number,
   url: String,
   subThemes: [subThemeSchema],
-  selectedPitch: {
-    type: String,
-    enum: ["C", "D", "E", "F", "G"],
-  },
-  dominantNode: {
-    type: String,
-    enum: ["C", "D", "E", "F", "G"],
-  },
+  selectedTone: Object,
+  userPitch: Object,
+  pitchStatus: Object,
   createdAt: String,
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,6 +172,11 @@
         "color-convert": "^2.0.1"
       }
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -188,6 +193,44 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "aws-sdk": {
+      "version": "2.1086.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1086.0.tgz",
+      "integrity": "sha512-iQb9UpvaJphZSJrNccN8xA3rQBG7mg29Qvgt2VG4XnUM4cwD/i4+gJ3V/rSmM4rzAWZMbTk04lal+KBn7ByNyw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -287,6 +330,20 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      }
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -366,6 +423,51 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -404,6 +506,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cors": {
       "version": "2.8.5",
@@ -453,6 +560,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -654,6 +770,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -734,6 +855,11 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -844,6 +970,11 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.0.2.tgz",
       "integrity": "sha512-QWlwUZZ8BtlvwYVTSDTBChGf8EOcQ2LkGMnQJxSzD1mUu8CCjXJZq/BXP8eWw4kikRnzlhtYo3lCk0ucmYA3Vg=="
+    },
+    "html-comment-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -980,11 +1111,21 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -1347,6 +1488,19 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "mongodb": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
@@ -1440,6 +1594,31 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.4.tgz",
+      "integrity": "sha512-2wY2+xD4udX612aMqMcB8Ws2Voq6NIUPEtD1be6m411T4uDH/VtL9i//xvcyFlTVfRdaBsk7hV5tgrGQqhuBiw==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      }
+    },
+    "multer-s3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/multer-s3/-/multer-s3-2.10.0.tgz",
+      "integrity": "sha512-RZsiqG19C9gE82lB7v8duJ+TMIf70fWYHlIwuNcsanOH1ePBoPXZvboEQxEow9jUkk7WQsuyVA2TgriOuDrVrw==",
+      "requires": {
+        "file-type": "^3.3.0",
+        "html-comment-regex": "^1.1.2",
+        "run-parallel": "^1.1.6"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -1575,6 +1754,11 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1593,6 +1777,16 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -1622,6 +1816,17 @@
             "toidentifier": "1.0.1"
           }
         }
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "regexpp": {
@@ -1661,6 +1866,14 @@
         "glob": "^7.1.3"
       }
     },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "rxjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
@@ -1688,6 +1901,11 @@
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "5.7.1",
@@ -1821,6 +2039,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -1854,6 +2077,11 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "6.0.1",
@@ -1949,6 +2177,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1963,10 +2196,36 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -2049,6 +2308,25 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/speech-mate/speech-mate-backend#readme",
   "dependencies": {
+    "aws-sdk": "^2.1086.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
@@ -27,7 +28,9 @@
     "http-errors": "^2.0.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.2.3",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "multer": "^1.4.4",
+    "multer-s3": "^2.10.0"
   },
   "devDependencies": {
     "eslint": "^8.10.0",

--- a/services/authService.js
+++ b/services/authService.js
@@ -5,24 +5,31 @@ const { MESSAGE } = require("../constants");
 
 const login = async (req, res, next) => {
   const { email, nickname, photo } = req.body;
+  const userInfo = {
+    email,
+    nickname,
+    photo,
+  };
 
   try {
-    let user = await User.findOneAndUpdate(
-      { email },
-      { email, nickname, photo },
-      { upsert: true, new: true },
-    );
+    let user = await User.findOneAndUpdate({ email }, userInfo, {
+      upsert: true,
+      new: true,
+    });
 
-    const accessToken = jwt.sign(
-      { email, nickname, photo },
-      process.env.ACCESS_TOKEN_SECRET,
-      { expiresIn: process.env.ACCESS_TOKEN_MAX_AGE },
-    );
+    const accessToken = jwt.sign(userInfo, process.env.ACCESS_TOKEN_SECRET, {
+      expiresIn: process.env.ACCESS_TOKEN_MAX_AGE,
+    });
+
+    const refreshToken = jwt.sign(userInfo, process.env.ACCESS_TOKEN_SECRET, {
+      expiresIn: process.env.REFRESH_TOKEN_MAX_AGE,
+    });
 
     res.json({
       message: MESSAGE.OK,
       data: {
         accessToken,
+        refreshToken,
         userInfo: user,
       },
     });
@@ -31,4 +38,46 @@ const login = async (req, res, next) => {
   }
 };
 
-module.exports = { login };
+const refreshToken = async (req, res, next) => {
+  const cookies = req.cookies;
+  const refreshToken = cookies.jwt;
+
+  if (!refreshToken) return next(createError(401, "Unauthorized"));
+
+  try {
+    jwt.verify(
+      refreshToken,
+      process.env.ACCESS_TOKEN_SECRET,
+      async (error, decoded) => {
+        if (error?.name === "TokenExpiredError") {
+          return next(createError(401, "Unauthorized"));
+        }
+
+        if (!decoded) return next(createError(403, "Forbidden"));
+        const { email, nickname, photo } = decoded;
+        const user = await User.findOne({ email });
+
+        if (error || !user) return next(createError(403, "Forbidden"));
+
+        const accessToken = jwt.sign(
+          { email, nickname, photo },
+          process.env.ACCESS_TOKEN_SECRET,
+          { expiresIn: process.env.REFRESH_TOKEN_MAX_AGE },
+        );
+
+        res.json({
+          message: MESSAGE.OK,
+          data: {
+            accessToken,
+            userInfo: user,
+          },
+        });
+      },
+    );
+  } catch (error) {
+    console.error(error);
+    next(error);
+  }
+};
+
+module.exports = { login, refreshToken };

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,3 +1,45 @@
+const createError = require("http-errors");
 const User = require("../models/User");
+const { MESSAGE } = require("../constants");
 
-module.exports = {};
+const createFile = async (req, res, next) => {
+  const { id } = req.params;
+  const { min, sec, title, frequency, subThemes, userPitch, selectedTone } =
+    req.body;
+  const { location } = req.file;
+
+  const newFile = {
+    title,
+    min: Number(min),
+    sec: Number(sec),
+    url: location,
+    subThemes: JSON.parse(subThemes),
+    selectedTone: JSON.parse(selectedTone),
+    userPitch: JSON.parse(userPitch),
+    pitchStatus: JSON.parse(frequency),
+    createdAt: new Date().toISOString(),
+  };
+
+  try {
+    const result = await User.findByIdAndUpdate(
+      id,
+      {
+        $push: { files: newFile },
+      },
+      { new: true },
+    );
+
+    console.log(result);
+
+    res.json({
+      message: MESSAGE.OK,
+      data: {
+        files: result.files,
+      },
+    });
+  } catch (err) {
+    next(createError(500, MESSAGE.INTERNAL_SERVER_ERROR));
+  }
+};
+
+module.exports = { createFile };

--- a/services/userService.js
+++ b/services/userService.js
@@ -2,6 +2,23 @@ const createError = require("http-errors");
 const User = require("../models/User");
 const { MESSAGE } = require("../constants");
 
+const readFiles = async (req, res, next) => {
+  const { id } = req.params;
+
+  try {
+    const result = await User.findById(id);
+
+    res.json({
+      message: MESSAGE.OK,
+      data: {
+        files: result.files,
+      },
+    });
+  } catch (err) {
+    next(createError(500, MESSAGE.INTERNAL_SERVER_ERROR));
+  }
+};
+
 const createFile = async (req, res, next) => {
   const { id } = req.params;
   const { min, sec, title, frequency, subThemes, userPitch, selectedTone } =
@@ -28,8 +45,6 @@ const createFile = async (req, res, next) => {
       },
       { new: true },
     );
-
-    console.log(result);
 
     res.json({
       message: MESSAGE.OK,
@@ -118,4 +133,4 @@ const deleteFile = async (req, res, next) => {
   }
 };
 
-module.exports = { createFile, updateFile, deleteFile };
+module.exports = { createFile, updateFile, deleteFile, readFiles };

--- a/services/userService.js
+++ b/services/userService.js
@@ -42,4 +42,80 @@ const createFile = async (req, res, next) => {
   }
 };
 
-module.exports = { createFile };
+const updateFile = async (req, res, next) => {
+  const { id, fileId } = req.params;
+  const { subThemes } = req.body;
+
+  try {
+    const user = await User.findById(id);
+    const newFiles = user.files.map((file) => {
+      if (file._id.toString() === fileId) {
+        const {
+          title,
+          min,
+          sec,
+          url,
+          selectedTone,
+          userPitch,
+          createdAt,
+          _id,
+        } = file;
+        return {
+          _id,
+          title,
+          min,
+          sec,
+          url,
+          selectedTone,
+          userPitch,
+          createdAt,
+          subThemes,
+        };
+      }
+      return file;
+    });
+
+    const result = await User.findByIdAndUpdate(
+      id,
+      { files: newFiles },
+      { new: true },
+    );
+
+    res.json({
+      message: MESSAGE.OK,
+      data: {
+        files: result.files,
+      },
+    });
+  } catch (err) {
+    next(createError(500, MESSAGE.INTERNAL_SERVER_ERROR));
+  }
+};
+
+const deleteFile = async (req, res, next) => {
+  const { id, fileId } = req.params;
+
+  try {
+    const user = await User.findById(id);
+    const newFiles = user.files.filter(
+      (file) => file._id.toString() !== fileId,
+    );
+
+    const result = await User.findByIdAndUpdate(
+      id,
+      { files: newFiles },
+      { new: true },
+    );
+
+    res.json({
+      message: MESSAGE.OK,
+      data: {
+        files: result.files,
+      },
+    });
+  } catch (err) {
+    next(createError(500, MESSAGE.INTERNAL_SERVER_ERROR));
+  }
+};
+
+module.exports = { createFile, updateFile, deleteFile };


### PR DESCRIPTION
# feature/multer s3

## 노션 칸반 링크

- [multer-s3 audio file s3 서버 업데이트 미들웨어 작성](https://www.notion.so/bc2a53e91cde4294856888e5b38fc6dc?v=cc148201de2a4782920edae951a023a4&p=cd32cc07a16046deb8a8298b3780dd02)
- [POST /users/:id/files](https://www.notion.so/bc2a53e91cde4294856888e5b38fc6dc?v=cc148201de2a4782920edae951a023a4&p=3a2b24e8a66647f983ff025829dd79ac)
- [PUT /users/:id/files/:fileId](https://www.notion.so/bc2a53e91cde4294856888e5b38fc6dc?v=cc148201de2a4782920edae951a023a4&p=5635ebc266a949fc88e58e96b43494b0)
- [DELETE /users/:id/files/:fileId](https://www.notion.so/bc2a53e91cde4294856888e5b38fc6dc?v=cc148201de2a4782920edae951a023a4&p=136569e01fb84a0bbabee299dd7d8347)

## 카드에서 구현 혹은 해결하려는 내용

- 파일 업로드시에는 uploadFile 미들웨어에서 formData안의 파일을 저장후 나머지 string 데이터는 다음 컨트롤러로 넘어가도록 구현
- 파일 삭제시에는 deleteFile 미들웨어에서 해당 파일을 삭제한 후 next() 호출하여 다음 컨트롤러로 넘어가도록 구현 

## 기타 사항
-로그인 유지시 사용되는 /auth/refresh 엔드포인트에서는 auth관련 정보만 클라이언트로 보내주기 때문에, 이 경우 files 정보만 따로 받을 수 있도록 GET /users/:id/files 엔드포인트 추가 작성
