### PR TITLE
fix: set s3 content type to audio/webm from video/webm

### DIFF
--- a/api/middlewares/uploadAudio.js
+++ b/api/middlewares/uploadAudio.js
@@ -10,9 +10,11 @@ const s3 = new AWS.S3({
 
 const storage = multerS3({
   s3,
-  contentType: multerS3.AUTO_CONTENT_TYPE,
   acl: "public-read",
   bucket: process.env.AWS_BUCKET_NAME,
+  contentType: (req, file, callback) => {
+    callback(null, file.mimetype);
+  },
 });
 
 const deleteAudio = async (req, res, next) => {


### PR DESCRIPTION
#fix: set s3 content type to audio/webm from video/webm

## 카드에서 구현 혹은 해결하려는 내용
![IMG_5751](https://user-images.githubusercontent.com/80205036/158447595-1bb42716-6f3b-4c3e-807f-c1d0ff01649c.jpg)
<img width="719" alt="스크린샷 2022-03-15 오후 4 36 48" src="https://user-images.githubusercontent.com/80205036/158447621-f05f4458-b655-41fe-8397-68c6447ddf46.png">

데스크탑 크롬에서는 정상 작동 하나, 모바일상에서는 오류가 뜨는 것으로 확인,
파일 타입 확인 결과 vedio/webm으로 확인 되므로 audio/webm으로 content type 지정해서 s3에 올라갈 수 있도록 코드 수정